### PR TITLE
デフォルトの読み方向を左綴じ（西洋式）に変更

### DIFF
--- a/Models/ReadingDirection.swift
+++ b/Models/ReadingDirection.swift
@@ -40,9 +40,9 @@ class ReadingSettings: ObservableObject {
     private let readingDirectionKey = "ToshoReadingDirection"
 
     init() {
-        // 保存された設定を読み込み、デフォルトは右綴じ（日本式）
-        let savedDirection = userDefaults.string(forKey: readingDirectionKey) ?? ReadingDirection.rightToLeft.rawValue
-        self.readingDirection = ReadingDirection(rawValue: savedDirection) ?? .rightToLeft
+        // 保存された設定を読み込み、デフォルトは左綴じ（西洋式）
+        let savedDirection = userDefaults.string(forKey: readingDirectionKey) ?? ReadingDirection.leftToRight.rawValue
+        self.readingDirection = ReadingDirection(rawValue: savedDirection) ?? .leftToRight
     }
 
     private func saveSettings() {


### PR DESCRIPTION
## Summary

デフォルトの読み方向を右綴じ（日本式）から左綴じ（西洋式）に変更

## 変更内容

- `ReadingSettings`の初期化時のデフォルト値を`.rightToLeft`から`.leftToRight`に変更
- 新規ユーザーおよび設定未保存時のデフォルト読み方向が左から右（西洋式）になります
- 既存ユーザーの保存済み設定は変更されません

## 影響

- 新しいユーザーは左綴じ（西洋式）で開始
- 既存ユーザーの設定は保持される
- 引き続き設定でいつでも読み方向の切り替えが可能

🤖 Generated with [Claude Code](https://claude.ai/code)