### PR TITLE
Issue #10 - Toshoギャラリー（サムネイル一覧表示）機能の実装

### DIFF
--- a/App/ToshoApp.swift
+++ b/App/ToshoApp.swift
@@ -80,6 +80,13 @@ struct ToshoApp: App {
                     NotificationCenter.default.post(name: .toggleFullScreen, object: nil)
                 }
                 .keyboardShortcut("F", modifiers: [.command, .control])
+
+                Divider()
+
+                Button("Show Gallery") {
+                    NotificationCenter.default.post(name: .toggleGallery, object: nil)
+                }
+                .keyboardShortcut("t", modifiers: [.command])
             }
         }
     }
@@ -187,4 +194,5 @@ extension Notification.Name {
     static let toggleDoublePage = Notification.Name("tosho.toggleDoublePage")
     static let toggleReadingDirection = Notification.Name("tosho.toggleReadingDirection")
     static let toggleFullScreen = Notification.Name("tosho.toggleFullScreen")
+    static let toggleGallery = Notification.Name("tosho.toggleGallery")
 }

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -39,7 +39,7 @@ class ReaderViewModel: ObservableObject {
     private var thumbnailCache: [Int: NSImage] = [:]
     private var document: ToshoDocument?
     private let cacheSize = 5
-    private let thumbnailSize = CGSize(width: 120, height: 180)
+    private let thumbnailSize = CGSize(width: 90, height: 130)
 
     var hasNextPage: Bool {
         if isDoublePageMode {

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -39,7 +39,7 @@ class ReaderViewModel: ObservableObject {
     private var thumbnailCache: [Int: NSImage] = [:]
     private var document: ToshoDocument?
     private let cacheSize = 5
-    private let thumbnailSize = CGSize(width: 150, height: 200)
+    private let thumbnailSize = CGSize(width: 120, height: 180)
 
     var hasNextPage: Bool {
         if isDoublePageMode {

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -8,6 +8,20 @@
 import SwiftUI
 import Combine
 
+// MARK: - NSImage Extension
+extension NSImage {
+    func resized(to newSize: CGSize) -> NSImage {
+        let newImage = NSImage(size: newSize)
+        newImage.lockFocus()
+        self.draw(in: NSRect(origin: .zero, size: newSize),
+                  from: NSRect(origin: .zero, size: self.size),
+                  operation: .sourceOver,
+                  fraction: 1.0)
+        newImage.unlockFocus()
+        return newImage
+    }
+}
+
 class ReaderViewModel: ObservableObject {
     @Published var currentImage: NSImage?
     @Published var secondImage: NSImage?
@@ -17,12 +31,15 @@ class ReaderViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var showControls: Bool = false
     @Published var isDoublePageMode: Bool = false
+    @Published var showGallery: Bool = false
 
     @ObservedObject var readingSettings = ReadingSettings()
 
     private var imageCache: [Int: NSImage] = [:]
+    private var thumbnailCache: [Int: NSImage] = [:]
     private var document: ToshoDocument?
     private let cacheSize = 5
+    private let thumbnailSize = CGSize(width: 150, height: 200)
 
     var hasNextPage: Bool {
         if isDoublePageMode {
@@ -301,6 +318,58 @@ class ReaderViewModel: ObservableObject {
         }
 
         loadImageAtIndex(adjustedIndex)
+    }
+
+    // MARK: - Gallery Functions
+
+    func toggleGallery() {
+        showGallery.toggle()
+    }
+
+    func jumpToPage(_ pageIndex: Int) {
+        guard pageIndex >= 0 && pageIndex < totalPages else { return }
+        showGallery = false
+        isLoading = true
+        loadImageAtIndex(pageIndex)
+    }
+
+    func getThumbnail(for pageIndex: Int) -> NSImage? {
+        // キャッシュから取得
+        if let thumbnail = thumbnailCache[pageIndex] {
+            return thumbnail
+        }
+
+        // バックグラウンドでサムネイル生成
+        generateThumbnail(for: pageIndex)
+        return nil
+    }
+
+    private func generateThumbnail(for pageIndex: Int) {
+        guard pageIndex >= 0 && pageIndex < totalPages,
+              let document = document else { return }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                if let image = try document.getImage(at: pageIndex) {
+                    let thumbnail = image.resized(to: self.thumbnailSize)
+                    DispatchQueue.main.async {
+                        self.thumbnailCache[pageIndex] = thumbnail
+                    }
+                }
+            } catch {
+                DebugLogger.shared.logError(error, context: "Failed to generate thumbnail for page \(pageIndex)")
+            }
+        }
+    }
+
+    func preloadThumbnails() {
+        DispatchQueue.global(qos: .utility).async {
+            for i in 0..<self.totalPages {
+                if self.thumbnailCache[i] == nil {
+                    self.generateThumbnail(for: i)
+                }
+            }
+        }
     }
 }
 

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -573,7 +573,7 @@ struct ThumbnailGalleryView: View {
     @Environment(\.presentationMode) var presentationMode
 
     private let columns = [
-        GridItem(.adaptive(minimum: 150, maximum: 200), spacing: 12)
+        GridItem(.adaptive(minimum: 120, maximum: 160), spacing: 16)
     ]
 
     var body: some View {
@@ -640,13 +640,14 @@ struct ThumbnailCard: View {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(Color.gray.opacity(0.2))
-                    .frame(height: 200)
+                    .frame(width: 120, height: 180)
 
                 if let thumbnail = thumbnail {
                     Image(nsImage: thumbnail)
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxHeight: 200)
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 120, height: 180)
+                        .clipped()
                         .cornerRadius(8)
                 } else {
                     VStack {

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -605,15 +605,15 @@ struct ThumbnailGalleryView: View {
                 }
             }
             .navigationTitle("Gallery")
-            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .navigation) {
                     Button("Close") {
                         viewModel.toggleGallery()
                     }
+                    .keyboardShortcut(.escape, modifiers: [])
                 }
 
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .primaryAction) {
                     Text("Page \(viewModel.currentPageIndex + 1) of \(viewModel.totalPages)")
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -696,17 +696,4 @@ struct ThumbnailCard: View {
     }
 }
 
-// MARK: - NSImage Extension
-extension NSImage {
-    func resized(to newSize: CGSize) -> NSImage {
-        let newImage = NSImage(size: newSize)
-        newImage.lockFocus()
-        self.draw(in: NSRect(origin: .zero, size: newSize),
-                  from: NSRect(origin: .zero, size: self.size),
-                  operation: .sourceOver,
-                  fraction: 1.0)
-        newImage.unlockFocus()
-        return newImage
-    }
-}
 

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -573,7 +573,7 @@ struct ThumbnailGalleryView: View {
     @Environment(\.presentationMode) var presentationMode
 
     private let columns = [
-        GridItem(.adaptive(minimum: 120, maximum: 160), spacing: 16)
+        GridItem(.adaptive(minimum: 90, maximum: 110), spacing: 20)
     ]
 
     var body: some View {
@@ -594,7 +594,8 @@ struct ThumbnailGalleryView: View {
                                 .id(pageIndex)
                             }
                         }
-                        .padding()
+                        .padding(.horizontal, 30)
+                        .padding(.vertical, 20)
                     }
                     .onAppear {
                         // 現在のページにスクロール
@@ -640,13 +641,13 @@ struct ThumbnailCard: View {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(Color.gray.opacity(0.2))
-                    .frame(width: 120, height: 180)
+                    .frame(width: 90, height: 130)
 
                 if let thumbnail = thumbnail {
                     Image(nsImage: thumbnail)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: 120, height: 180)
+                        .frame(width: 90, height: 130)
                         .clipped()
                         .cornerRadius(8)
                 } else {

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -207,6 +207,9 @@ struct ReaderView: View {
                 // アプリがアクティブになった時にフォーカスを設定
                 NSApp.keyWindow?.makeFirstResponder(nil)
             }
+            .sheet(isPresented: $viewModel.showGallery) {
+                ThumbnailGalleryView(viewModel: viewModel)
+            }
         }
     }
 
@@ -276,6 +279,14 @@ struct ReaderView: View {
             queue: .main
         ) { _ in
             viewModel.toggleReadingDirection()
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .toggleGallery,
+            object: nil,
+            queue: .main
+        ) { _ in
+            viewModel.toggleGallery()
         }
     }
 }


### PR DESCRIPTION
## Summary

Issue #10 「🖼️ Phase 3: Toshoギャラリー（サムネイル一覧表示）」の実装

現在開いている漫画のページサムネイル一覧を表示し、素早くページジャンプできる機能

## 主要な変更

### 新機能
- **ThumbnailGalleryView**: グリッド表示のサムネイル一覧
- **サムネイル生成**: 非同期での縮小画像生成（150x200px）
- **インメモリキャッシュ**: 高速アクセスのためのキャッシュ管理
- **Cmd+T ショートカット**: ギャラリーの表示/非表示切り替え

### 変更ファイル
- `ViewModels/ReaderViewModel.swift` - サムネイル管理機能追加
- `Views/ContentView.swift` - ThumbnailGalleryView追加
- `Views/ReaderView.swift` - ギャラリー統合
- `App/ToshoApp.swift` - Cmd+Tショートカット追加

## 実装機能

✅ **ThumbnailView**
- グリッドレイアウトでサムネイル表示
- 現在のページのハイライト表示
- サムネイルクリックでページジャンプ

✅ **サムネイル生成**
- 画像の縮小版を非同期生成
- インメモリキャッシュ管理
- バックグラウンドでの一括プリロード

✅ **UI/UX**
- **Cmd+T** でギャラリー表示
- 現在ページへの自動スクロール
- ホバー効果とスプリングアニメーション
- ESCキーやCloseボタンで終了

## Test plan

- [ ] Cmd+Tでギャラリービューが開くことを確認
- [ ] すべてのページのサムネイルが表示されることを確認
- [ ] サムネイルクリックで該当ページにジャンプすることを確認
- [ ] 現在のページがハイライトされることを確認
- [ ] 大量ページでのパフォーマンステスト

🤖 Generated with [Claude Code](https://claude.ai/code)