### PR TITLE
自動お気に入り機能の実装

### DIFF
--- a/App/ToshoApp.swift
+++ b/App/ToshoApp.swift
@@ -35,6 +35,11 @@ struct ToshoApp: App {
                 }
                 .keyboardShortcut("H", modifiers: [.command, .shift])
 
+                Button("Favorites...") {
+                    showFavorites()
+                }
+                .keyboardShortcut("F", modifiers: [.command, .shift])
+
                 if !recentFilesManager.recentFiles.isEmpty {
                     Divider()
 
@@ -161,6 +166,10 @@ struct ToshoApp: App {
     private func showRecentFiles() {
         NotificationCenter.default.post(name: .showRecentFiles, object: nil)
     }
+
+    private func showFavorites() {
+        NotificationCenter.default.post(name: .showFavorites, object: nil)
+    }
 }
 
 // MARK: - App Delegate
@@ -189,6 +198,8 @@ extension Notification.Name {
     static let showRecentFiles = Notification.Name("tosho.showRecentFiles")
     static let recentFileOpened = Notification.Name("tosho.recentFileOpened")
     static let closeRecentFiles = Notification.Name("tosho.closeRecentFiles")
+    static let showFavorites = Notification.Name("tosho.showFavorites")
+    static let closeFavorites = Notification.Name("tosho.closeFavorites")
     static let nextPage = Notification.Name("tosho.nextPage")
     static let previousPage = Notification.Name("tosho.previousPage")
     static let toggleDoublePage = Notification.Name("tosho.toggleDoublePage")

--- a/Tosho.xcodeproj/project.pbxproj
+++ b/Tosho.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		TD647232D17360463790FABUILD /* ToshoDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = TD1CCDBAE5544641D29995 /* ToshoDocument.swift */; };
 		RD8472A3E12B59C7F891BUILD /* ReadingDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = RD5A39B8C47E28D4A653F0 /* ReadingDirection.swift */; };
 		DL8472A3E12B59C7F891BUILD /* DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DL5A39B8C47E28D4A653F0 /* DebugLogger.swift */; };
+		FAV72B4E9C3D8A5F1234567 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAV51A3B7C8E4D6F9012345 /* FavoritesView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +34,7 @@
 		TD1CCDBAE5544641D29995 /* ToshoDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToshoDocument.swift; sourceTree = "<group>"; };
 		RD5A39B8C47E28D4A653F0 /* ReadingDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDirection.swift; sourceTree = "<group>"; };
 		DL5A39B8C47E28D4A653F0 /* DebugLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogger.swift; sourceTree = "<group>"; };
+		FAV51A3B7C8E4D6F9012345 /* FavoritesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesView.swift; sourceTree = "<group>"; };
 		DOC001A1000001000000AA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DOC002A1000001000000AA /* CLAUDE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CLAUDE.md; sourceTree = "<group>"; };
 		DOC003A1000001000000AA /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			children = (
 				D0000004A1000001000000AA /* ContentView.swift */,
 				D0000006A1000001000000AA /* ReaderView.swift */,
+				FAV51A3B7C8E4D6F9012345 /* FavoritesView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -239,6 +242,7 @@
 				TD647232D17360463790FABUILD /* ToshoDocument.swift in Sources */,
 				RD8472A3E12B59C7F891BUILD /* ReadingDirection.swift in Sources */,
 				DL8472A3E12B59C7F891BUILD /* DebugLogger.swift in Sources */,
+				FAV72B4E9C3D8A5F1234567 /* FavoritesView.swift in Sources */,
 				D0000001A1000001000000AA /* ToshoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -40,6 +40,7 @@ class ReaderViewModel: ObservableObject {
     private var document: ToshoDocument?
     private let cacheSize = 5
     private let thumbnailSize = CGSize(width: 90, height: 130)
+    private let favoritesManager = FavoritesManager.shared
 
     var hasNextPage: Bool {
         if isDoublePageMode {
@@ -68,6 +69,9 @@ class ReaderViewModel: ObservableObject {
         isLoading = true
         errorMessage = nil
         DebugLogger.shared.log("Starting to load content from: \(url.lastPathComponent)", category: "ReaderViewModel")
+
+        // ファイルアクセスを記録
+        favoritesManager.recordFileAccess(url)
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             do {

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var showingRecentFiles = false
+    @State private var showingFavorites = false
 
     var body: some View {
         ZStack {
@@ -52,6 +53,9 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showingRecentFiles) {
             RecentFilesView()
+        }
+        .sheet(isPresented: $showingFavorites) {
+            FavoritesView()
         }
     }
 
@@ -100,6 +104,22 @@ struct ContentView: View {
             if let url = notification.object as? URL {
                 selectedFileURL = url
             }
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .showFavorites,
+            object: nil,
+            queue: .main
+        ) { _ in
+            showingFavorites = true
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .closeFavorites,
+            object: nil,
+            queue: .main
+        ) { _ in
+            showingFavorites = false
         }
     }
 

--- a/Views/FavoritesView.swift
+++ b/Views/FavoritesView.swift
@@ -1,0 +1,309 @@
+//
+//  FavoritesView.swift
+//  Tosho
+//
+//  Created on 2025/09/27.
+//
+
+import SwiftUI
+
+struct FavoritesView: View {
+    @ObservedObject private var favoritesManager = FavoritesManager.shared
+    @State private var selectedTab: FavoritesTab = .favorites
+    @State private var searchText = ""
+
+    enum FavoritesTab: String, CaseIterable {
+        case favorites = "お気に入り"
+        case frequent = "よく開く"
+        case suggestions = "候補"
+        case history = "履歴"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            VStack(spacing: 16) {
+                HStack {
+                    Text("ファイル管理")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+
+                    Spacer()
+
+                    Button("履歴をクリア") {
+                        showClearHistoryAlert()
+                    }
+                    .buttonStyle(.bordered)
+                    .foregroundColor(.red)
+                }
+
+                // Search
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.secondary)
+
+                    TextField("ファイル名で検索", text: $searchText)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                // Tab Selection
+                Picker("タブ", selection: $selectedTab) {
+                    ForEach(FavoritesTab.allCases, id: \.self) { tab in
+                        Text(tab.rawValue).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+            .padding()
+
+            Divider()
+
+            // Content
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    ForEach(filteredItems) { item in
+                        FileHistoryCard(
+                            item: item,
+                            showFavoriteButton: selectedTab != .favorites,
+                            onOpen: { openFile(item.url) },
+                            onToggleFavorite: { toggleFavorite(item) },
+                            onDismissSuggestion: selectedTab == .suggestions ? { dismissSuggestion(item) } : nil
+                        )
+                    }
+                }
+                .padding()
+            }
+
+            if filteredItems.isEmpty {
+                Spacer()
+                VStack(spacing: 16) {
+                    Image(systemName: emptyStateIcon)
+                        .font(.system(size: 50))
+                        .foregroundColor(.secondary)
+
+                    Text(emptyStateMessage)
+                        .font(.title3)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                Spacer()
+            }
+        }
+        .frame(minWidth: 600, minHeight: 400)
+    }
+
+    private var filteredItems: [FileHistoryItem] {
+        let items: [FileHistoryItem]
+
+        switch selectedTab {
+        case .favorites:
+            items = favoritesManager.getFavorites()
+        case .frequent:
+            items = favoritesManager.getFrequentlyAccessed()
+        case .suggestions:
+            items = favoritesManager.autoFavoriteSuggestions
+        case .history:
+            items = favoritesManager.fileHistory
+        }
+
+        if searchText.isEmpty {
+            return items
+        } else {
+            return items.filter { item in
+                item.fileName.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+    }
+
+    private var emptyStateIcon: String {
+        switch selectedTab {
+        case .favorites: return "heart"
+        case .frequent: return "clock"
+        case .suggestions: return "lightbulb"
+        case .history: return "doc.text"
+        }
+    }
+
+    private var emptyStateMessage: String {
+        switch selectedTab {
+        case .favorites: return "お気に入りのファイルがありません"
+        case .frequent: return "よく開くファイルがありません"
+        case .suggestions: return "お気に入り候補がありません"
+        case .history: return "ファイル履歴がありません"
+        }
+    }
+
+    private func openFile(_ url: URL) {
+        NotificationCenter.default.post(name: .openFile, object: url)
+    }
+
+    private func toggleFavorite(_ item: FileHistoryItem) {
+        favoritesManager.setFavorite(item.url, favorite: !item.isFavorite)
+    }
+
+    private func dismissSuggestion(_ item: FileHistoryItem) {
+        favoritesManager.dismissAutoFavoriteSuggestion(item.url)
+    }
+
+    private func showClearHistoryAlert() {
+        let alert = NSAlert()
+        alert.messageText = "履歴をクリアしますか？"
+        alert.informativeText = "すべてのファイル履歴とお気に入り情報が削除されます。この操作は取り消せません。"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "クリア")
+        alert.addButton(withTitle: "キャンセル")
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            favoritesManager.clearHistory()
+        }
+    }
+}
+
+struct FileHistoryCard: View {
+    let item: FileHistoryItem
+    let showFavoriteButton: Bool
+    let onOpen: () -> Void
+    let onToggleFavorite: () -> Void
+    let onDismissSuggestion: (() -> Void)?
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                // File Icon
+                Image(systemName: fileIcon)
+                    .font(.title2)
+                    .foregroundColor(iconColor)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    // File Name
+                    Text(item.fileName)
+                        .font(.headline)
+                        .lineLimit(1)
+
+                    // Details
+                    HStack(spacing: 12) {
+                        Label(item.formattedAccessCount, systemImage: "clock")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        Label(item.formattedLastAccessed, systemImage: "calendar")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                // Action Buttons
+                HStack(spacing: 8) {
+                    if let dismissAction = onDismissSuggestion {
+                        Button(action: dismissAction) {
+                            Image(systemName: "xmark.circle")
+                                .foregroundColor(.red)
+                        }
+                        .buttonStyle(.plain)
+                        .help("候補を却下")
+                    }
+
+                    if showFavoriteButton {
+                        Button(action: onToggleFavorite) {
+                            Image(systemName: item.isFavorite ? "heart.fill" : "heart")
+                                .foregroundColor(item.isFavorite ? .red : .secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help(item.isFavorite ? "お気に入りから削除" : "お気に入りに追加")
+                    }
+
+                    Button(action: onOpen) {
+                        Text("開く")
+                            .font(.caption)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            // Auto-favorite suggestion banner
+            if item.shouldBeAutoFavorite && !item.isFavorite {
+                HStack {
+                    Image(systemName: "lightbulb.fill")
+                        .foregroundColor(.orange)
+
+                    Text("このファイルをお気に入りに追加することをお勧めします")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+
+                    Spacer()
+
+                    Button("追加") {
+                        onToggleFavorite()
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundColor(.orange)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.orange.opacity(0.1))
+                .cornerRadius(6)
+            }
+        }
+        .padding()
+        .background(backgroundColor)
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(borderColor, lineWidth: 1)
+        )
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .scaleEffect(isHovered ? 1.02 : 1.0)
+        .animation(.easeInOut(duration: 0.1), value: isHovered)
+    }
+
+    private var fileIcon: String {
+        let ext = item.url.pathExtension.lowercased()
+        if ext == "zip" || ext == "cbz" {
+            return "archivebox"
+        } else {
+            return "doc"
+        }
+    }
+
+    private var iconColor: Color {
+        let ext = item.url.pathExtension.lowercased()
+        if ext == "zip" || ext == "cbz" {
+            return .blue
+        } else {
+            return .gray
+        }
+    }
+
+    private var backgroundColor: Color {
+        if item.isFavorite {
+            return Color.red.opacity(0.05)
+        } else if item.shouldBeAutoFavorite {
+            return Color.orange.opacity(0.05)
+        } else {
+            return Color(NSColor.controlBackgroundColor)
+        }
+    }
+
+    private var borderColor: Color {
+        if item.isFavorite {
+            return Color.red.opacity(0.3)
+        } else if item.shouldBeAutoFavorite {
+            return Color.orange.opacity(0.3)
+        } else {
+            return Color.gray.opacity(0.2)
+        }
+    }
+}
+
+#Preview {
+    FavoritesView()
+        .frame(width: 700, height: 600)
+}


### PR DESCRIPTION
## 概要
ファイルアクセス履歴を記録し、使用頻度に基づいて自動的にお気に入り候補を提案する機能を実装しました。

## 実装内容

### 📊 データモデル
- **FileHistoryItem**: ファイルアクセス履歴を追跡
  - アクセス回数、初回・最終アクセス日時
  - お気に入り・自動お気に入りフラグ
  - アクセス回数5回以上で自動お気に入り候補

### 🏗️ FavoritesManager
- ファイルアクセス履歴の永続化（UserDefaults）
- 自動お気に入り候補の管理
- よく開くファイルの抽出
- 通知による自動お気に入り提案

### 🎨 ユーザーインターフェース
- **FavoritesView**: 4つのタブでファイル管理
  - お気に入り：手動で追加したファイル
  - よく開く：アクセス回数3回以上のファイル
  - 候補：自動お気に入り提案（5回以上アクセス）
  - 履歴：全ファイルアクセス履歴
- 検索機能でファイル名フィルタリング
- アクセス回数と日時の表示

### ⌨️ キーボードショートカット
- `Cmd+Shift+F`: お気に入り画面を表示

### 🔄 統合機能
- ReaderViewModel でファイルオープン時に自動記録
- NotificationCenter による画面間連携
- 自動お気に入り候補の通知表示

## テスト方法
1. 同じZIPファイルを5回以上開く
2. 自動お気に入り候補として通知される
3. `Cmd+Shift+F` でお気に入り画面を開く
4. 「候補」タブで自動提案を確認

🤖 Generated with [Claude Code](https://claude.ai/code)