### PR TITLE
見開きモードでの1ページ単位調整機能を追加

### DIFF
--- a/App/ToshoApp.swift
+++ b/App/ToshoApp.swift
@@ -71,6 +71,18 @@ struct ToshoApp: App {
 
                 Divider()
 
+                Button("Adjust Forward (+)") {
+                    NotificationCenter.default.post(name: .adjustPageForward, object: nil)
+                }
+                .keyboardShortcut("+", modifiers: [])
+
+                Button("Adjust Backward (-)") {
+                    NotificationCenter.default.post(name: .adjustPageBackward, object: nil)
+                }
+                .keyboardShortcut("-", modifiers: [])
+
+                Divider()
+
                 Button("Toggle Double Page") {
                     NotificationCenter.default.post(name: .toggleDoublePage, object: nil)
                 }
@@ -202,6 +214,8 @@ extension Notification.Name {
     static let closeFavorites = Notification.Name("tosho.closeFavorites")
     static let nextPage = Notification.Name("tosho.nextPage")
     static let previousPage = Notification.Name("tosho.previousPage")
+    static let adjustPageForward = Notification.Name("tosho.adjustPageForward")
+    static let adjustPageBackward = Notification.Name("tosho.adjustPageBackward")
     static let toggleDoublePage = Notification.Name("tosho.toggleDoublePage")
     static let toggleReadingDirection = Notification.Name("tosho.toggleReadingDirection")
     static let toggleFullScreen = Notification.Name("tosho.toggleFullScreen")

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -324,6 +324,54 @@ class ReaderViewModel: ObservableObject {
         loadImageAtIndex(adjustedIndex)
     }
 
+    // MARK: - 見開きモード用1ページ単位調整
+
+    func adjustPageForward() {
+        guard isDoublePageMode else {
+            // 単ページモードでは通常のnextPageと同じ
+            nextPage()
+            return
+        }
+
+        guard currentPageIndex < totalPages - 1 else { return }
+
+        var newIndex = currentPageIndex + 1
+
+        // 表紙（0ページ）から1ページ目に移動する場合
+        if currentPageIndex == 0 {
+            newIndex = 1
+        } else {
+            // 通常の1ページ進み
+            newIndex = min(currentPageIndex + 1, totalPages - 1)
+        }
+
+        isLoading = true
+        loadImageAtIndex(newIndex)
+    }
+
+    func adjustPageBackward() {
+        guard isDoublePageMode else {
+            // 単ページモードでは通常のpreviousPageと同じ
+            previousPage()
+            return
+        }
+
+        guard currentPageIndex > 0 else { return }
+
+        var newIndex = currentPageIndex - 1
+
+        // 1ページ目から表紙（0ページ）に戻る場合
+        if currentPageIndex == 1 {
+            newIndex = 0
+        } else {
+            // 通常の1ページ戻り
+            newIndex = max(currentPageIndex - 1, 0)
+        }
+
+        isLoading = true
+        loadImageAtIndex(newIndex)
+    }
+
     // MARK: - Gallery Functions
 
     func toggleGallery() {

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -288,6 +288,22 @@ struct ReaderView: View {
         ) { _ in
             viewModel.toggleGallery()
         }
+
+        NotificationCenter.default.addObserver(
+            forName: .adjustPageForward,
+            object: nil,
+            queue: .main
+        ) { _ in
+            viewModel.adjustPageForward()
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .adjustPageBackward,
+            object: nil,
+            queue: .main
+        ) { _ in
+            viewModel.adjustPageBackward()
+        }
     }
 }
 


### PR DESCRIPTION
## 概要
見開きモードで2ページずつしか送れない問題を解決するため、1ページずつ微調整できる機能を実装しました。

## 変更内容
### 新機能
- **1ページ単位調整**: 見開きモードでも1ページずつ前進・後退が可能
- **キーボードショートカット**: `+`キーで前進、`-`キーで後退
- **既存機能との併用**: 通常のページ送り（Space/Shift+Space）は2ページずつ、新機能は1ページずつ

### 実装詳細
- `ReaderViewModel.swift`: `adjustPageForward()`, `adjustPageBackward()` メソッド追加
- `ToshoApp.swift`: Viewメニューに調整機能とキーボードショートカット追加
- `ReaderView.swift`: NotificationCenter経由でのイベント処理追加

### 動作仕様
- **単ページモード**: 新機能は通常のページ送りと同じ動作
- **見開きモード**: 
  - 通常のページ送り（Space/Shift+Space）: 2ページずつ移動
  - 新しい調整機能（+/-）: 1ページずつ微調整
  - 表紙（0ページ）と1ページ目の適切な処理
  - 右綴じ・左綴じの読書方向に対応

## テスト方法
1. 見開きモードでファイルを開く
2. `+`キーで1ページずつ前進することを確認
3. `-`キーで1ページずつ後退することを確認
4. Spaceキーで従来通り2ページずつ移動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)