### PR TITLE
Xcodeプロジェクトから削除されたRecentFilesView.swiftの参照を削除

### DIFF
--- a/Tosho.xcodeproj/project.pbxproj
+++ b/Tosho.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		RD8472A3E12B59C7F891BUILD /* ReadingDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = RD5A39B8C47E28D4A653F0 /* ReadingDirection.swift */; };
 		DL8472A3E12B59C7F891BUILD /* DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DL5A39B8C47E28D4A653F0 /* DebugLogger.swift */; };
 		FAV72B4E9C3D8A5F1234567 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAV51A3B7C8E4D6F9012345 /* FavoritesView.swift */; };
-		REC84C3A5B9D7E2F6123456 /* RecentFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = REC62F1C8A4B6D9E3456789 /* RecentFilesView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,7 +35,6 @@
 		RD5A39B8C47E28D4A653F0 /* ReadingDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDirection.swift; sourceTree = "<group>"; };
 		DL5A39B8C47E28D4A653F0 /* DebugLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogger.swift; sourceTree = "<group>"; };
 		FAV51A3B7C8E4D6F9012345 /* FavoritesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesView.swift; sourceTree = "<group>"; };
-		REC62F1C8A4B6D9E3456789 /* RecentFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesView.swift; sourceTree = "<group>"; };
 		DOC001A1000001000000AA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DOC002A1000001000000AA /* CLAUDE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CLAUDE.md; sourceTree = "<group>"; };
 		DOC003A1000001000000AA /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
@@ -101,7 +99,6 @@
 				D0000004A1000001000000AA /* ContentView.swift */,
 				D0000006A1000001000000AA /* ReaderView.swift */,
 				FAV51A3B7C8E4D6F9012345 /* FavoritesView.swift */,
-				REC62F1C8A4B6D9E3456789 /* RecentFilesView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -246,7 +243,6 @@
 				RD8472A3E12B59C7F891BUILD /* ReadingDirection.swift in Sources */,
 				DL8472A3E12B59C7F891BUILD /* DebugLogger.swift in Sources */,
 				FAV72B4E9C3D8A5F1234567 /* FavoritesView.swift in Sources */,
-				REC84C3A5B9D7E2F6123456 /* RecentFilesView.swift in Sources */,
 				D0000001A1000001000000AA /* ToshoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## 概要
履歴システム統一の実装後、Xcodeプロジェクトファイルに残っていた削除済みRecentFilesView.swiftへの参照を削除し、ビルドエラーを修正。

## 修正内容
- **PBXBuildFile**: RecentFilesView.swiftのビルド参照を削除
- **PBXFileReference**: RecentFilesView.swiftのファイル参照を削除  
- **Views Group**: ファイルリストからの参照を削除
- **Sources Build Phase**: ビルドフェーズからの参照を削除

## 修正理由
PR #50 で履歴システムをFavoritesManagerに統一した際、RecentFilesView.swiftファイルは削除されましたが、Xcodeプロジェクトファイル内の参照が残っていたため、以下のビルドエラーが発生していました：

```
Build input file cannot be found: '/Users/yast/git/tosho/Views/RecentFilesView.swift'
```

## テスト計画
- [x] `make quality` でビルド成功を確認
- [x] Xcodeプロジェクトファイル内にRecentFilesView参照が存在しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)