### PR TITLE
ネットワークドライブ履歴ファイルのセキュリティスコープアクセス権限エラーを修正

### DIFF
--- a/App/ToshoApp.swift
+++ b/App/ToshoApp.swift
@@ -168,7 +168,17 @@ struct ToshoApp: App {
     }
 
     private func openRecentFile(_ url: URL) {
-        openAndAddToRecent(url)
+        // 履歴からファイルを開く際はセキュリティスコープを処理
+        favoritesManager.openFileFromHistory(url) { securityScopedURL in
+            guard let fileURL = securityScopedURL else {
+                DebugLogger.shared.log("Failed to get security scoped URL for: \(url.lastPathComponent)", category: "ToshoApp")
+                return
+            }
+
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .recentFileOpened, object: fileURL)
+            }
+        }
     }
 
 

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -42,6 +42,15 @@ class ReaderViewModel: ObservableObject {
     private let thumbnailSize = CGSize(width: 90, height: 130)
     private let favoritesManager = FavoritesManager.shared
     private var preloadTask: Task<Void, Never>? // 事前ロードタスク
+    private var currentFileURL: URL? // セキュリティスコープ管理用
+
+    deinit {
+        // セキュリティスコープのアクセス権限を終了
+        if let fileURL = currentFileURL {
+            favoritesManager.stopAccessingFileFromHistory(fileURL)
+        }
+        preloadTask?.cancel()
+    }
 
     var hasNextPage: Bool {
         if isDoublePageMode {
@@ -74,6 +83,9 @@ class ReaderViewModel: ObservableObject {
 
         // 既存のプリロードタスクをキャンセル
         preloadTask?.cancel()
+
+        // 現在のファイルURLを保存（セキュリティスコープ管理用）
+        currentFileURL = url
 
         // ファイルアクセスを記録
         favoritesManager.recordFileAccess(url)


### PR DESCRIPTION
## 概要
履歴から直接ネットワークドライブ上のZIPファイルを開く際に発生する「Operation not permitted」エラーを修正。

## 問題詳細
```
error: cannot open zipfile [/Volumes/manga/極貧ちゃんがパパ活して、ラブラブ夫婦になる話.zip]
Operation not permitted
unzip: cannot find or open /Volumes/manga/...zip
Exit code: 9
```

macOSでは、ファイルピッカー以外からネットワークドライブのファイルにアクセスする際、セキュリティスコープのアクセス権限（bookmark data）が必要だが、履歴システムでこれが適切に管理されていなかった。

## 解決策

### 🔐 セキュリティスコープブックマーク管理
- **FileHistoryItem**: bookmark dataでセキュリティスコープ権限を永続化
- **FavoritesManager**: 履歴からの安全なファイルアクセス API
- **ReaderViewModel**: アクセス権限の適切なライフサイクル管理

### 📁 実装詳細

#### FileHistoryItem拡張
```swift
private(set) var bookmarkData: Data? // セキュリティスコープ保持用

func getSecurityScopedURL() -> URL? // アクセス権限付きURL取得
func startAccessingSecurityScopedResource() -> Bool // アクセス開始
func stopAccessingSecurityScopedResource() // アクセス終了
```

#### FavoritesManager API
```swift
func openFileFromHistory(_ url: URL, completion: @escaping (URL?) -> Void)
func stopAccessingFileFromHistory(_ url: URL)
```

### 🔄 アクセスフロー
1. **履歴保存時**: セキュリティスコープブックマーク作成
2. **履歴から開く時**: ブックマークからアクセス権限付きURL復元
3. **ファイル表示中**: セキュリティスコープアクセス継続
4. **ファイル終了時**: アクセス権限適切に終了

## テスト計画
- [x] ビルド成功確認（`make quality`）
- [ ] ネットワークドライブからの履歴ファイルアクセス
- [ ] セキュリティスコープ権限の開始/終了確認
- [ ] 複数ファイル切り替え時のメモリリーク確認

## 影響範囲
- **互換性**: 既存履歴データは自動的にセキュリティスコープなしで動作
- **パフォーマンス**: ブックマーク作成/復元のわずかなオーバーヘッド
- **セキュリティ**: macOSのセキュリティポリシーに準拠した適切なアクセス管理

🤖 Generated with [Claude Code](https://claude.ai/code)