### PR TITLE
feat: ZIP読み込み中のユーザー操作を制限

### DIFF
--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -287,7 +287,7 @@ class ReaderViewModel: ObservableObject {
     // MARK: - 古いキャッシュシステムは削除（全画像プリロード方式では不要）
 
     func nextPage() {
-        guard hasNextPage else { return }
+        guard hasNextPage && !isLoading else { return }
 
         var newIndex: Int
         if isDoublePageMode {
@@ -313,7 +313,7 @@ class ReaderViewModel: ObservableObject {
     }
 
     func previousPage() {
-        guard hasPreviousPage else { return }
+        guard hasPreviousPage && !isLoading else { return }
 
         var newIndex: Int
         if isDoublePageMode {
@@ -381,6 +381,8 @@ class ReaderViewModel: ObservableObject {
     // MARK: - 見開きモード用1ページ単位調整
 
     func adjustPageForward() {
+        guard !isLoading else { return }
+
         guard isDoublePageMode else {
             // 単ページモードでは通常のnextPageと同じ
             nextPage()
@@ -409,6 +411,8 @@ class ReaderViewModel: ObservableObject {
     }
 
     func adjustPageBackward() {
+        guard !isLoading else { return }
+
         guard isDoublePageMode else {
             // 単ページモードでは通常のpreviousPageと同じ
             previousPage()
@@ -443,7 +447,7 @@ class ReaderViewModel: ObservableObject {
     }
 
     func jumpToPage(_ pageIndex: Int) {
-        guard pageIndex >= 0 && pageIndex < totalPages else { return }
+        guard pageIndex >= 0 && pageIndex < totalPages && !isLoading else { return }
         showGallery = false
 
         // 全画像プリロード方式では即座に表示

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -136,7 +136,7 @@ struct ReaderView: View {
 
                 // Navigation Controls Overlay
                 HStack {
-                    if viewModel.hasPreviousPage {
+                    if viewModel.hasPreviousPage && !viewModel.isLoading {
                         Button(action: { viewModel.previousPage() }) {
                             Image(systemName: "chevron.left")
                                 .font(.title)
@@ -151,7 +151,7 @@ struct ReaderView: View {
 
                     Spacer()
 
-                    if viewModel.hasNextPage {
+                    if viewModel.hasNextPage && !viewModel.isLoading {
                         Button(action: { viewModel.nextPage() }) {
                             Image(systemName: "chevron.right")
                                 .font(.title)


### PR DESCRIPTION
## 概要
ZIPファイル読み込み中にユーザーがページ操作を行えないよう制限を追加しました。

## 変更内容
- **ReaderViewModel**: 各ページ移動メソッドに `!isLoading` チェックを追加
  - `nextPage()`, `previousPage()`, `adjustPageForward()`, `adjustPageBackward()`, `jumpToPage()`
- **ReaderView**: ナビゲーションボタンに `!viewModel.isLoading` 条件を追加

## 効果
- ZIPファイルの初期化中はキーボードショートカットでのページ移動が無効化
- UIナビゲーションボタンが非表示になり、マウス操作も制限
- ギャラリーからのページジャンプも制限
- 既存の進捗表示（「全画像を読み込み中...」）は引き続き表示

## テスト手順
1. 大きなZIPファイルを開く
2. 読み込み中にキーボードショートカット（矢印キー等）でページ移動を試行
3. ナビゲーションボタンが非表示になっていることを確認
4. 読み込み完了後に正常にページ操作できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)