### PR TITLE
feat: マルチウィンドウサポートと新しいウィンドウをデフォルト動作に変更

### DIFF
--- a/Models/ToshoDocument.swift
+++ b/Models/ToshoDocument.swift
@@ -14,6 +14,7 @@ enum ContentType {
     case archive(URL, [String])
 }
 
+
 class ToshoDocument: ObservableObject {
     @Published var contentType: ContentType?
     @Published var totalPages: Int = 0

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -45,11 +45,19 @@ class ReaderViewModel: ObservableObject {
     private var currentFileURL: URL? // セキュリティスコープ管理用
 
     deinit {
+        DebugLogger.shared.log("ReaderViewModel deinitializing", category: "ReaderViewModel")
+
         // セキュリティスコープのアクセス権限を終了
         if let fileURL = currentFileURL {
             favoritesManager.stopAccessingFileFromHistory(fileURL)
         }
         preloadTask?.cancel()
+
+        // 画像キャッシュをクリア
+        allImages.removeAll()
+        thumbnailCache.removeAll()
+
+        DebugLogger.shared.log("ReaderViewModel memory released", category: "ReaderViewModel")
     }
 
     var hasNextPage: Bool {

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -10,20 +10,15 @@ import AppKit
 import UniformTypeIdentifiers
 
 struct ContentView: View {
-    @State private var selectedFileURL: URL?
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var showingFavorites = false
 
     var body: some View {
         ZStack {
-            if let url = selectedFileURL {
-                ReaderView(fileURL: url)
-            } else {
-                WelcomeView(
-                    onOpen: openFileOrFolder
-                )
-            }
+            WelcomeView(
+                onOpen: openFileOrFolder
+            )
 
             if isLoading {
                 ProgressView()
@@ -62,7 +57,7 @@ struct ContentView: View {
             queue: .main
         ) { notification in
             if let url = notification.object as? URL {
-                selectedFileURL = url
+                self.openInNewWindow(url)
             }
         }
 
@@ -72,7 +67,7 @@ struct ContentView: View {
             queue: .main
         ) { notification in
             if let url = notification.object as? URL {
-                selectedFileURL = url
+                self.openInNewWindow(url)
             }
         }
 
@@ -82,7 +77,7 @@ struct ContentView: View {
             queue: .main
         ) { notification in
             if let url = notification.object as? URL {
-                selectedFileURL = url
+                self.openInNewWindow(url)
             }
         }
 
@@ -114,7 +109,7 @@ struct ContentView: View {
             }
 
             DispatchQueue.main.async {
-                self.selectedFileURL = url
+                self.openInNewWindow(url)
             }
         }
     }
@@ -148,7 +143,16 @@ struct ContentView: View {
         panel.allowedContentTypes = contentTypes
 
         if panel.runModal() == .OK {
-            selectedFileURL = panel.url
+            if let url = panel.url {
+                // 新しいウィンドウで開く
+                openInNewWindow(url)
+            }
+        }
+    }
+
+    private func openInNewWindow(_ url: URL) {
+        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            appDelegate.openNewReaderWindow(with: url)
         }
     }
 }

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -8,10 +8,22 @@
 import SwiftUI
 
 struct ReaderView: View {
-    let fileURL: URL
-    @StateObject private var viewModel = ReaderViewModel()
+    let fileURL: URL?
+    @ObservedObject var viewModel: ReaderViewModel
     @State private var currentZoom: CGFloat = 1.0
     @State private var offset: CGSize = .zero
+
+    // Legacy initializer for existing ContentView
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+        self.viewModel = ReaderViewModel()
+    }
+
+    // New initializer for DocumentReaderView
+    init(viewModel: ReaderViewModel) {
+        self.fileURL = nil
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         GeometryReader { _ in
@@ -211,7 +223,9 @@ struct ReaderView: View {
                 }
             }
             .onAppear {
-                viewModel.loadContent(from: fileURL)
+                if let fileURL = fileURL {
+                    viewModel.loadContent(from: fileURL)
+                }
                 setupNotificationObservers()
             }
             .onHover { hovering in


### PR DESCRIPTION
## 概要
複数のZIPファイルを同時に開けるマルチウィンドウ機能を実装し、すべてのファイル操作を新しいウィンドウで開くデフォルト動作に変更しました。

## 主要な変更内容

### マルチウィンドウサポート
- AppDelegateに`openNewReaderWindow(with:)`メソッドを追加
- NSWindowを直接作成して独立したReaderViewインスタンスを管理
- 各ウィンドウで独自のReaderViewModelを使用してメモリを分離

### デフォルト動作の変更
- メインの「Open...」(⌘O)ボタンを新しいウィンドウで開くように変更
- 履歴ファイルも直接新しいウィンドウで開くようシンプル化
- ドラッグ&ドロップも新しいウィンドウで開くように変更
- ウィンドウ再利用機能を完全削除

### メモリ管理の改善
- ReaderViewModelのdeinitでデバッグログとメモリクリーンアップを追加
- 画像キャッシュの完全解放処理を実装

### UI/UXの改善
- ContentViewは常にWelcomeViewを表示（ウィンドウ再利用しないため）
- 不要なメニューアイテムとコードを削除してシンプル化

## 効果
- 複数のZIPファイルを同時に開いて比較可能
- ウィンドウクローズ時の自動メモリ解放
- より直感的な操作体験（常に新しいウィンドウで開く）

## テスト手順
1. アプリを起動してメインウィンドウのWelcomeViewを確認
2. 「Open...」ボタンまたは⌘Oでファイル選択し、新しいウィンドウが開くことを確認
3. 複数のファイルを開いて同時表示されることを確認
4. ウィンドウを閉じてメモリが解放されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)