### PR TITLE
デフォルト読み方向を右綴じ（日本式）に変更

### DIFF
--- a/Models/ReadingDirection.swift
+++ b/Models/ReadingDirection.swift
@@ -40,9 +40,9 @@ class ReadingSettings: ObservableObject {
     private let readingDirectionKey = "ToshoReadingDirection"
 
     init() {
-        // 保存された設定を読み込み、デフォルトは左綴じ（西洋式）
-        let savedDirection = userDefaults.string(forKey: readingDirectionKey) ?? ReadingDirection.leftToRight.rawValue
-        self.readingDirection = ReadingDirection(rawValue: savedDirection) ?? .leftToRight
+        // 保存された設定を読み込み、デフォルトは右綴じ（日本式）
+        let savedDirection = userDefaults.string(forKey: readingDirectionKey) ?? ReadingDirection.rightToLeft.rawValue
+        self.readingDirection = ReadingDirection(rawValue: savedDirection) ?? .rightToLeft
     }
 
     private func saveSettings() {


### PR DESCRIPTION
## 概要
マンガリーダーアプリとして適切なデフォルト読み方向を設定するため、初期値を右綴じ（日本式）に変更しました。

## 変更内容
- `ReadingSettings`のデフォルト値を`leftToRight`から`rightToLeft`に変更
- コメントを「左綴じ（西洋式）」から「右綴じ（日本式）」に更新

## 理由
- **日本のマンガは右綴じが標準的な読み方**
- 新規ユーザーがアプリを初回起動時により自然に使用開始できる
- マンガリーダーとしての期待される動作との一致

## 影響範囲

### ✅ 新規ユーザー
- アプリ初回起動時に右綴じモードでスタート
- 日本のマンガの自然な読み方向で開始

### ✅ 既存ユーザー
- **設定変更なし** - UserDefaultsに保存済みの設定が優先される
- 現在の読み方向設定は保持される

### 📱 動作変更
- 見開き表示時のページ順序: 右ページ→左ページ
- ページめくり方向: 右から左への自然な流れ
- UIインジケーター: 「右綴じ」表示

## テスト確認事項
- [x] 新規インストール時のデフォルト動作確認
- [x] 既存設定の保持確認
- [x] 読み方向切り替え機能の動作確認

## ファイル変更
- `Models/ReadingDirection.swift`: デフォルト値変更のみ

🤖 Generated with [Claude Code](https://claude.ai/code)