### PR TITLE
Add reading session manager architecture

### DIFF
--- a/Managers/ReadingSessionManager.swift
+++ b/Managers/ReadingSessionManager.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Coordinates lifecycle of reader sessions.
+/// Main-actor confined dictionary keeps bookkeeping simple
+/// while individual sessions can perform async work internally.
+@MainActor
+final class ReadingSessionManager {
+    static let shared = ReadingSessionManager()
+
+    private var sessions: [UUID: ReadingSession] = [:]
+
+    private init() {}
+
+    /// Start and register a new session for the provided URL.
+    @discardableResult
+    func startSession(for url: URL) -> ReadingSession {
+        let session = ReadingSession(sourceURL: url)
+        sessions[session.id] = session
+        return session
+    }
+
+    /// Retrieve a session by identifier.
+    func session(withID id: UUID) -> ReadingSession? {
+        sessions[id]
+    }
+
+    /// Gracefully terminate and remove a session.
+    func closeSession(withID id: UUID) {
+        guard let session = sessions[id] else { return }
+        Task { await session.prepareForClose() }
+        sessions.removeValue(forKey: id)
+    }
+
+    /// Close all active sessions – typically on app termination.
+    func closeAllSessions() {
+        let snapshot = Array(sessions.values)
+        snapshot.forEach { session in
+            Task { await session.prepareForClose() }
+        }
+        sessions.removeAll()
+    }
+}

--- a/Sessions/ReadingSession.swift
+++ b/Sessions/ReadingSession.swift
@@ -1,0 +1,123 @@
+import Foundation
+import SwiftUI
+import AppKit
+
+/// Represents the lifecycle of a single reader window.
+/// Owns the `ReaderViewModel`, manages background tasks,
+/// and coordinates security scoped resource access.
+@MainActor
+final class ReadingSession: ObservableObject, Identifiable {
+    enum State: String {
+        case initializing
+        case active
+        case closing
+        case closed
+    }
+
+    let id: UUID
+    let sourceURL: URL
+
+    @Published private(set) var state: State = .initializing
+    @Published private(set) var viewModel: ReaderViewModel
+
+    private let favoritesManager = FavoritesManager.shared
+    private var securityScopedURL: URL?
+    private var smartPreloadTask: Task<Void, Never>?
+    private var legacyPreloadTask: Task<Void, Never>?
+
+    init(sourceURL: URL, autoLoad: Bool = true) {
+        self.id = UUID()
+        self.sourceURL = sourceURL
+        self.viewModel = ReaderViewModel()
+
+        DebugLogger.shared.log("ReadingSession \(id) created for \(sourceURL.lastPathComponent)", category: "ReadingSession")
+
+        setupSecurityScopeIfNeeded()
+        if autoLoad {
+            attachViewModel()
+        } else {
+            viewModel.attachToSession(self)
+            state = .active
+        }
+    }
+
+    private func attachViewModel() {
+        viewModel.attachToSession(self)
+        favoritesManager.recordFileAccess(resolvedURL)
+        state = .active
+        viewModel.loadInitialContent(from: resolvedURL)
+    }
+
+    private func setupSecurityScopeIfNeeded() {
+        // If we already have access to the URL, keep it as-is.
+        // Attempt to resolve via favorites history to obtain bookmark access when available.
+        if let historyItem = favoritesManager.fileHistory.first(where: { $0.url == sourceURL }) {
+            var mutableItem = historyItem
+            if mutableItem.startAccessingSecurityScopedResource() {
+                securityScopedURL = mutableItem.getSecurityScopedURL()
+                DebugLogger.shared.log("ReadingSession \(id): acquired security scoped URL", category: "ReadingSession")
+            } else {
+                DebugLogger.shared.log("ReadingSession \(id): failed to acquire security scope for \(sourceURL.path)", category: "ReadingSession")
+            }
+        }
+    }
+
+    private var resolvedURL: URL {
+        securityScopedURL ?? sourceURL
+    }
+
+    func registerSmartPreloadTask(_ task: Task<Void, Never>) {
+        smartPreloadTask = task
+    }
+
+    func registerLegacyPreloadTask(_ task: Task<Void, Never>) {
+        legacyPreloadTask = task
+    }
+
+    /// Called when the owning window is about to close.
+    func prepareForClose() async {
+        guard state != .closing && state != .closed else { return }
+        state = .closing
+
+        DebugLogger.shared.log("ReadingSession \(id): preparing for close", category: "ReadingSession")
+        viewModel.prepareForClose()
+
+        let smartTask = smartPreloadTask
+        let legacyTask = legacyPreloadTask
+
+        smartTask?.cancel()
+        legacyTask?.cancel()
+
+        smartPreloadTask = nil
+        legacyPreloadTask = nil
+
+        if let smartTask {
+            _ = await smartTask.value
+        }
+
+        if let legacyTask {
+            _ = await legacyTask.value
+        }
+
+        releaseSecurityScope()
+        state = .closed
+        DebugLogger.shared.log("ReadingSession \(id): closed", category: "ReadingSession")
+    }
+
+    private func releaseSecurityScope() {
+        guard securityScopedURL != nil else { return }
+        favoritesManager.stopAccessingFileFromHistory(sourceURL)
+        securityScopedURL = nil
+    }
+}
+
+#if DEBUG
+extension ReadingSession {
+    static func previewSession() -> ReadingSession {
+        let session = ReadingSession(sourceURL: URL(fileURLWithPath: "/tmp/preview.jpg"), autoLoad: false)
+        session.viewModel.currentImage = NSImage(size: NSSize(width: 600, height: 800))
+        session.viewModel.totalPages = 1
+        return session
+    }
+}
+#endif

--- a/Tosho.xcodeproj/project.pbxproj
+++ b/Tosho.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		RD8472A3E12B59C7F891BUILD /* ReadingDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = RD5A39B8C47E28D4A653F0 /* ReadingDirection.swift */; };
 		DL8472A3E12B59C7F891BUILD /* DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DL5A39B8C47E28D4A653F0 /* DebugLogger.swift */; };
 		FAV72B4E9C3D8A5F1234567 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAV51A3B7C8E4D6F9012345 /* FavoritesView.swift */; };
+		054D1CB7FDC143609B7DF65D /* ReadingSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7905416B2764EF99583CCF3 /* ReadingSessionManager.swift */; };
+		E62F9B4E42D7464BB1CB2ABD /* ReadingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09242FF2A604432B435199B /* ReadingSession.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +40,8 @@
 		DOC001A1000001000000AA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DOC002A1000001000000AA /* CLAUDE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CLAUDE.md; sourceTree = "<group>"; };
 		DOC003A1000001000000AA /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		B7905416B2764EF99583CCF3 /* ReadingSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionManager.swift; sourceTree = "<group>"; };
+		D09242FF2A604432B435199B /* ReadingSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSession.swift; sourceTree = "<group>"; };
 		DOC004A1000001000000AA /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		DOC005A1000001000000AA /* dependabot.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = dependabot.yml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -70,6 +74,8 @@
 				D0000014A1000001000000AA /* Models */,
 				D0000015A1000001000000AA /* Services */,
 				D0000016A1000001000000AA /* Utilities */,
+				61E34390AD6941A380A913E7 /* Managers */,
+				09BB329D0561454298EECDA6 /* Sessions */,
 				D0000017A1000001000000AA /* Resources */,
 				DOC100A1000001000000AA /* Documentation */,
 			);
@@ -135,6 +141,22 @@
 				DL5A39B8C47E28D4A653F0 /* DebugLogger.swift */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		61E34390AD6941A380A913E7 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				B7905416B2764EF99583CCF3 /* ReadingSessionManager.swift */,
+			);
+			path = Managers;
+			sourceTree = "<group>";
+		};
+		09BB329D0561454298EECDA6 /* Sessions */ = {
+			isa = PBXGroup;
+			children = (
+				D09242FF2A604432B435199B /* ReadingSession.swift */,
+			);
+			path = Sessions;
 			sourceTree = "<group>";
 		};
 		D0000017A1000001000000AA /* Resources */ = {
@@ -264,6 +286,8 @@
 				D0000007A1000001000000AA /* ReaderViewModel.swift in Sources */,
 				AE5F3155A07FC84B49909FBUILD /* ArchiveExtractor.swift in Sources */,
 				ZE8F4D37B2C6A5E9F1234567 /* ZipExtractor.swift in Sources */,
+				054D1CB7FDC143609B7DF65D /* ReadingSessionManager.swift in Sources */,
+				E62F9B4E42D7464BB1CB2ABD /* ReadingSession.swift in Sources */,
 				TD647232D17360463790FABUILD /* ToshoDocument.swift in Sources */,
 				RD8472A3E12B59C7F891BUILD /* ReadingDirection.swift in Sources */,
 				DL8472A3E12B59C7F891BUILD /* DebugLogger.swift in Sources */,

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -8,21 +8,14 @@
 import SwiftUI
 
 struct ReaderView: View {
-    let fileURL: URL?
-    @ObservedObject var viewModel: ReaderViewModel
+    @ObservedObject private var session: ReadingSession
+    @ObservedObject private var viewModel: ReaderViewModel
     @State private var currentZoom: CGFloat = 1.0
     @State private var offset: CGSize = .zero
 
-    // Legacy initializer for existing ContentView
-    init(fileURL: URL) {
-        self.fileURL = fileURL
-        self.viewModel = ReaderViewModel()
-    }
-
-    // New initializer for DocumentReaderView
-    init(viewModel: ReaderViewModel) {
-        self.fileURL = nil
-        self.viewModel = viewModel
+    init(session: ReadingSession) {
+        self._session = ObservedObject(initialValue: session)
+        self._viewModel = ObservedObject(initialValue: session.viewModel)
     }
 
     var body: some View {
@@ -267,11 +260,6 @@ struct ReaderView: View {
                     .hidden()
                 }
             }
-            .onAppear {
-                if let fileURL = fileURL {
-                    viewModel.loadContent(from: fileURL)
-                }
-            }
             .onHover { hovering in
                 viewModel.showControls = hovering
             }
@@ -379,7 +367,7 @@ struct ReaderView: View {
 // MARK: - Preview
 struct ReaderView_Previews: PreviewProvider {
     static var previews: some View {
-        ReaderView(fileURL: URL(fileURLWithPath: "/path/to/image.jpg"))
+        ReaderView(session: ReadingSession.previewSession())
             .frame(width: 1200, height: 900)
     }
 }


### PR DESCRIPTION
## 概要
- 複数ウィンドウ／ZIP を安全に扱えるよう、セッション管理アーキテクチャを導入
- ReadingSessionManager と ReadingSession を追加し、ウィンドウ単位でタスクキャンセルとセキュリティスコープ解放を統括
- ReaderViewModel/ReaderView/AppDelegate をセッション連携方式にリファクタし、旧 deinit 依存のリソース解放を廃止

## 動作確認
- [ ] make build
- [ ] 複数の ZIP を同時に開いて閉じてもクラッシュしないことを確認
