### PR TITLE
Respect DEVELOPER_DIR when detecting Xcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
 # Xcode detection
-DEVELOPER_DIR := $(shell xcode-select -p 2>/dev/null)
-HAVE_FULL_XCODE := $(shell if [[ "$(DEVELOPER_DIR)" == *"Xcode.app"* ]] && [ -x "$(DEVELOPER_DIR)/usr/bin/xcodebuild" ]; then echo yes; else echo no; fi)
+# Respect an existing DEVELOPER_DIR (e.g. provided by CI) and fall back to xcode-select.
+DEVELOPER_DIR ?= $(shell xcode-select -p 2>/dev/null)
+HAVE_FULL_XCODE := $(shell if [ -n "$(DEVELOPER_DIR)" ] && [ -x "$(DEVELOPER_DIR)/usr/bin/xcodebuild" ]; then echo yes; else echo no; fi)
 
 # Project Configuration
 PROJECT_NAME = Tosho


### PR DESCRIPTION
## Summary
- honor an externally provided `DEVELOPER_DIR` before falling back to `xcode-select`
- tighten the Xcode detection check to only look for `xcodebuild`
- ensures CI runners that set `DEVELOPER_DIR` use the full Xcode toolchain instead of the swiftc fallback

## Testing
- not run (CI will run)
