### PR TITLE
feat: リーダー画像のオンデマンド読み込みに刷新 (#72)

### DIFF
--- a/Sessions/ReadingSession.swift
+++ b/Sessions/ReadingSession.swift
@@ -23,7 +23,6 @@ final class ReadingSession: ObservableObject, Identifiable {
     private let favoritesManager = FavoritesManager.shared
     private var securityScopedURL: URL?
     private var smartPreloadTask: Task<Void, Never>?
-    private var legacyPreloadTask: Task<Void, Never>?
 
     init(sourceURL: URL, autoLoad: Bool = true) {
         self.id = UUID()
@@ -70,10 +69,6 @@ final class ReadingSession: ObservableObject, Identifiable {
         smartPreloadTask = task
     }
 
-    func registerLegacyPreloadTask(_ task: Task<Void, Never>) {
-        legacyPreloadTask = task
-    }
-
     /// Called when the owning window is about to close.
     func prepareForClose() async {
         guard state != .closing && state != .closed else { return }
@@ -83,20 +78,12 @@ final class ReadingSession: ObservableObject, Identifiable {
         viewModel.prepareForClose()
 
         let smartTask = smartPreloadTask
-        let legacyTask = legacyPreloadTask
-
         smartTask?.cancel()
-        legacyTask?.cancel()
 
         smartPreloadTask = nil
-        legacyPreloadTask = nil
 
         if let smartTask {
             _ = await smartTask.value
-        }
-
-        if let legacyTask {
-            _ = await legacyTask.value
         }
 
         releaseSecurityScope()


### PR DESCRIPTION
## 概要
- ReaderViewModel の全画像プリロード依存を廃止し、キャッシュ優先で必要分だけを非同期ロードするパイプラインに差し替え
- 画像キャッシュに LRU 同期とファイル単位パージ機能を追加し、ウィンドウクローズ時に確実に解放
- セッション終了処理を簡素化し、不要なタスク待機/キャッシュ保持を削除

Closes #72

## テスト
- Building Tosho (Debug)...
⚠️  Full Xcode not available, running Swift type-check instead...
✓ Swift type-check passed
All quality checks completed!
