### PR TITLE
feat: Finderライブラリのキャッシュ最適化

### DIFF
--- a/Tosho.xcodeproj/project.pbxproj
+++ b/Tosho.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		D0000003A1000001000000AA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0000004A1000001000000AA /* ContentView.swift */; };
 		D0000005A1000001000000AA /* ReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0000006A1000001000000AA /* ReaderView.swift */; };
 		D0000007A1000001000000AA /* ReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0000008A1000001000000AA /* ReaderViewModel.swift */; };
+		FNB1A2C3D4E5F60708090A0B /* FileNavigatorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FNB1A2C3D4E5F60708090A0A /* FileNavigatorViewModel.swift */; };
 		D0000009A1000001000000AA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D000000AA1000001000000AA /* Assets.xcassets */; };
 		AE5F3155A07FC84B49909FBUILD /* ArchiveExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4C3DC8F29A8947FEBD80 /* ArchiveExtractor.swift */; };
 		ZE8F4D37B2C6A5E9F1234567 /* ZipExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ZE9F2E48D3A5B1C6F7890123 /* ZipExtractor.swift */; };
@@ -27,6 +28,7 @@
 		D0000004A1000001000000AA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D0000006A1000001000000AA /* ReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderView.swift; sourceTree = "<group>"; };
 		D0000008A1000001000000AA /* ReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderViewModel.swift; sourceTree = "<group>"; };
+		FNB1A2C3D4E5F60708090A0A /* FileNavigatorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileNavigatorViewModel.swift; sourceTree = "<group>"; };
 		D000000AA1000001000000AA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D000000BA1000001000000AA /* Tosho.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tosho.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D000000CA1000001000000AA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				D0000008A1000001000000AA /* ReaderViewModel.swift */,
+				FNB1A2C3D4E5F60708090A0A /* FileNavigatorViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				D0000003A1000001000000AA /* ContentView.swift in Sources */,
 				D0000005A1000001000000AA /* ReaderView.swift in Sources */,
 				D0000007A1000001000000AA /* ReaderViewModel.swift in Sources */,
+				FNB1A2C3D4E5F60708090A0B /* FileNavigatorViewModel.swift in Sources */,
 				AE5F3155A07FC84B49909FBUILD /* ArchiveExtractor.swift in Sources */,
 				ZE8F4D37B2C6A5E9F1234567 /* ZipExtractor.swift in Sources */,
 				054D1CB7FDC143609B7DF65D /* ReadingSessionManager.swift in Sources */,

--- a/ViewModels/FileNavigatorViewModel.swift
+++ b/ViewModels/FileNavigatorViewModel.swift
@@ -1,0 +1,382 @@
+import Foundation
+import AppKit
+
+struct FileNavigatorItem: Identifiable, Hashable {
+    let url: URL
+    let isDirectory: Bool
+    var children: [FileNavigatorItem]?
+
+    var id: URL { url }
+    var name: String { url.lastPathComponent }
+}
+
+@MainActor
+final class FileNavigatorViewModel: ObservableObject {
+    @Published private(set) var rootURL: URL?
+    @Published private(set) var items: [FileNavigatorItem] = []
+    @Published var selectedURL: URL?
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var lastRefreshed: Date?
+
+    private let fileManager = FileManager.default
+    private let userDefaults = UserDefaults.standard
+    private let rootBookmarkKey = "FinderRootBookmark"
+    private let maxInitialDepth = 1
+    private let cacheTTL: TimeInterval = 1200 // 20 minutes
+
+    private var securityScopedRoot: URL?
+    private var treeLoadTask: Task<Void, Never>?
+    private var directoryLoadTasks: [URL: Task<Void, Never>] = [:]
+
+    private struct CachedEntry {
+        var item: FileNavigatorItem
+        var timestamp: Date
+    }
+
+    private var cache: [URL: CachedEntry] = [:]
+
+    private let directoryOptions: FileManager.DirectoryEnumerationOptions = [.skipsHiddenFiles]
+    private let supportedExtensions: Set<String> = [
+        "jpg", "jpeg", "png", "gif", "tiff", "bmp", "heic", "webp", "avif",
+        "zip", "cbz"
+    ]
+
+    init() {
+        restoreRootFromBookmark()
+    }
+
+    deinit {
+        treeLoadTask?.cancel()
+        directoryLoadTasks.values.forEach { $0.cancel() }
+        securityScopedRoot?.stopAccessingSecurityScopedResource()
+    }
+
+    var hasRoot: Bool { rootURL != nil }
+
+    func updateRoot(to url: URL) {
+        startAccessing(url)
+        persistBookmark(for: url)
+        rootURL = url
+        refreshTree(force: true)
+    }
+
+    func clearRoot() {
+        treeLoadTask?.cancel()
+        directoryLoadTasks.values.forEach { $0.cancel() }
+        directoryLoadTasks.removeAll()
+
+        securityScopedRoot?.stopAccessingSecurityScopedResource()
+        securityScopedRoot = nil
+
+        rootURL = nil
+        items = []
+        selectedURL = nil
+        isLoading = false
+        lastRefreshed = nil
+        cache.removeAll()
+
+        userDefaults.removeObject(forKey: rootBookmarkKey)
+    }
+
+    func refreshTree(force: Bool = false) {
+        treeLoadTask?.cancel()
+
+        guard let rootURL else {
+            items = []
+            selectedURL = nil
+            lastRefreshed = nil
+            return
+        }
+
+        if !force, let cached = cache[rootURL], Date().timeIntervalSince(cached.timestamp) < cacheTTL {
+            items = [cached.item]
+            if selectedURL == nil { selectedURL = cached.item.url }
+            isLoading = false
+            lastRefreshed = cached.timestamp
+            return
+        }
+
+        isLoading = true
+        let fm = fileManager
+        let supported = supportedExtensions
+        let options = directoryOptions
+        let targetURL = rootURL
+        let maxDepth = maxInitialDepth
+
+        treeLoadTask = Task(priority: .userInitiated) { [weak self] in
+            let result = FileNavigatorViewModel.makeItem(
+                at: targetURL,
+                depth: 0,
+                maxDepth: maxDepth,
+                supportedExtensions: supported,
+                fileManager: fm,
+                options: options
+            )
+
+            await MainActor.run {
+                guard let self = self else { return }
+                guard self.rootURL == targetURL else { return }
+                if Task.isCancelled { return }
+
+                if let result {
+                    self.items = [result]
+                    if self.selectedURL == nil { self.selectedURL = result.url }
+                    let now = Date()
+                    self.cache[targetURL] = CachedEntry(item: result, timestamp: now)
+                    self.lastRefreshed = now
+                } else {
+                    self.items = []
+                    self.selectedURL = nil
+                    self.cache.removeValue(forKey: targetURL)
+                    self.lastRefreshed = Date()
+                }
+
+                self.isLoading = false
+            }
+        }
+    }
+
+    func children(of url: URL) -> [FileNavigatorItem] {
+        if shouldReloadChildren(for: url) {
+            enqueueChildLoad(for: url)
+        }
+        return currentChildren(of: url)
+    }
+
+    func forceRefreshDirectory(at url: URL) {
+        if url == rootURL {
+            refreshTree(force: true)
+            return
+        }
+        directoryLoadTasks[url]?.cancel()
+        directoryLoadTasks[url] = nil
+        cache.removeValue(forKey: url)
+        enqueueChildLoad(for: url)
+    }
+
+    func isDirectory(_ url: URL) -> Bool {
+        guard let root = items.first else { return false }
+        return findItem(in: root, matching: url)?.isDirectory ?? false
+    }
+
+    func isSupportedFile(_ url: URL) -> Bool {
+        supportedExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    func lastUpdated(for url: URL) -> Date? {
+        cache[url]?.timestamp
+    }
+
+    // MARK: - Private helpers
+
+    private func currentChildren(of url: URL) -> [FileNavigatorItem] {
+        guard let root = items.first,
+              let item = findItem(in: root, matching: url) else { return [] }
+        return item.children ?? []
+    }
+
+    private func shouldReloadChildren(for url: URL) -> Bool {
+        guard let entry = cache[url] else { return true }
+        let expired = Date().timeIntervalSince(entry.timestamp) >= cacheTTL
+        let hasChildren = entry.item.children != nil
+        return expired || !hasChildren
+    }
+
+    private func enqueueChildLoad(for url: URL) {
+        guard directoryLoadTasks[url] == nil else { return }
+        guard isDirectory(url) else { return }
+
+        let depth = depthFromRoot(of: url)
+        let fm = fileManager
+        let supported = supportedExtensions
+        let options = directoryOptions
+        let nextMaxDepth = depth + 1
+
+        directoryLoadTasks[url] = Task(priority: .userInitiated) { [weak self] in
+            guard let self = self else { return }
+            let children = FileNavigatorViewModel.loadDirectoryEntries(
+                for: url,
+                depth: depth,
+                maxDepth: nextMaxDepth,
+                supportedExtensions: supported,
+                fileManager: fm,
+                options: options
+            )
+
+            await MainActor.run {
+                self.applyChildren(children, to: url)
+                self.cache[url] = CachedEntry(item: FileNavigatorItem(url: url, isDirectory: true, children: children), timestamp: Date())
+                self.directoryLoadTasks[url] = nil
+            }
+        }
+    }
+
+    private func applyChildren(_ children: [FileNavigatorItem], to url: URL) {
+        guard !items.isEmpty else { return }
+        items = items.map { update(item: $0, target: url, newChildren: children) }
+        if let root = items.first {
+            let timestamp = (url == root.url) ? Date() : (cache[root.url]?.timestamp ?? Date())
+            cache[root.url] = CachedEntry(item: root, timestamp: timestamp)
+            if url == root.url {
+                lastRefreshed = timestamp
+            }
+        }
+    }
+
+    private func update(item: FileNavigatorItem, target: URL, newChildren: [FileNavigatorItem]) -> FileNavigatorItem {
+        var copy = item
+        if item.url == target {
+            copy.children = newChildren
+            return copy
+        }
+
+        if let existingChildren = item.children {
+            var updatedChildren = existingChildren
+            var changed = false
+            for index in existingChildren.indices {
+                let updated = update(item: existingChildren[index], target: target, newChildren: newChildren)
+                if updated.url == target || updated.children != existingChildren[index].children {
+                    updatedChildren[index] = updated
+                    changed = true
+                }
+            }
+            if changed {
+                copy.children = updatedChildren
+            }
+        }
+        return copy
+    }
+
+    private func depthFromRoot(of url: URL) -> Int {
+        guard let rootURL else { return 0 }
+        let rootComponents = rootURL.standardizedFileURL.pathComponents
+        let targetComponents = url.standardizedFileURL.pathComponents
+        return max(targetComponents.count - rootComponents.count, 0)
+    }
+
+    private func findItem(in item: FileNavigatorItem, matching url: URL) -> FileNavigatorItem? {
+        if item.url == url { return item }
+        guard let children = item.children else { return nil }
+        for child in children {
+            if let match = findItem(in: child, matching: url) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    private func startAccessing(_ url: URL) {
+        securityScopedRoot?.stopAccessingSecurityScopedResource()
+        if url.startAccessingSecurityScopedResource() {
+            securityScopedRoot = url
+        } else {
+            securityScopedRoot = nil
+        }
+    }
+
+    private func persistBookmark(for url: URL) {
+        do {
+            let bookmark = try url.bookmarkData(options: [.withSecurityScope], includingResourceValuesForKeys: nil, relativeTo: nil)
+            userDefaults.set(bookmark, forKey: rootBookmarkKey)
+        } catch {
+            DebugLogger.shared.logError(error, context: "Failed to save finder root bookmark")
+        }
+    }
+
+    private func restoreRootFromBookmark() {
+        guard let bookmark = userDefaults.data(forKey: rootBookmarkKey) else { return }
+        do {
+            var isStale = false
+            let url = try URL(resolvingBookmarkData: bookmark, options: [.withSecurityScope], relativeTo: nil, bookmarkDataIsStale: &isStale)
+            startAccessing(url)
+            if isStale {
+                persistBookmark(for: url)
+            }
+            rootURL = url
+            refreshTree()
+        } catch {
+            DebugLogger.shared.logError(error, context: "Failed to restore finder root bookmark")
+            userDefaults.removeObject(forKey: rootBookmarkKey)
+        }
+    }
+
+    // MARK: - Static helpers
+
+    nonisolated private static func makeItem(
+        at url: URL,
+        depth: Int,
+        maxDepth: Int,
+        supportedExtensions: Set<String>,
+        fileManager: FileManager,
+        options: FileManager.DirectoryEnumerationOptions
+    ) -> FileNavigatorItem? {
+        if Task.isCancelled { return nil }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return nil
+        }
+
+        if isDirectory.boolValue {
+            var children: [FileNavigatorItem]? = nil
+            if depth < maxDepth {
+                children = loadDirectoryEntries(
+                    for: url,
+                    depth: depth,
+                    maxDepth: maxDepth,
+                    supportedExtensions: supportedExtensions,
+                    fileManager: fileManager,
+                    options: options
+                )
+            }
+            return FileNavigatorItem(url: url, isDirectory: true, children: children)
+        } else {
+            guard supportedExtensions.contains(url.pathExtension.lowercased()) else {
+                return nil
+            }
+            return FileNavigatorItem(url: url, isDirectory: false, children: nil)
+        }
+    }
+
+    nonisolated private static func loadDirectoryEntries(
+        for directory: URL,
+        depth: Int,
+        maxDepth: Int,
+        supportedExtensions: Set<String>,
+        fileManager: FileManager,
+        options: FileManager.DirectoryEnumerationOptions
+    ) -> [FileNavigatorItem] {
+        if Task.isCancelled { return [] }
+
+        guard let enumerator = fileManager.enumerator(at: directory, includingPropertiesForKeys: nil, options: options.union([.skipsSubdirectoryDescendants])) else {
+            return []
+        }
+
+        var collected: [URL] = []
+        for case let child as URL in enumerator {
+            collected.append(child)
+        }
+
+        let mapped: [FileNavigatorItem] = collected.compactMap { child in
+            makeItem(
+                at: child,
+                depth: depth + 1,
+                maxDepth: maxDepth,
+                supportedExtensions: supportedExtensions,
+                fileManager: fileManager,
+                options: options
+            )
+        }
+
+        return sortItems(mapped)
+    }
+
+    nonisolated private static func sortItems(_ items: [FileNavigatorItem]) -> [FileNavigatorItem] {
+        items.sorted { lhs, rhs in
+            if lhs.isDirectory == rhs.isDirectory {
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+            return lhs.isDirectory && !rhs.isDirectory
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- Finder 風ナビゲーションを非ブロッキング化し、初回はルート1階層のみ走査・表示
- サブフォルダを開いたタイミングでその階層だけをバックグラウンドでスキャンし、最終更新時刻付きでキャッシュ
- キャッシュの TTL を 20 分に延長。任意フォルダの手動再読み込みと更新タイムスタンプ表示を追加

## テスト
- Building Tosho (Debug)...
⚠️  Full Xcode not available, running Swift type-check instead...
✓ Swift type-check passed
All quality checks completed!
